### PR TITLE
Add LikeAnimationView for heart fill animation when liking a post

### DIFF
--- a/DogGram.xcodeproj/project.pbxproj
+++ b/DogGram.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		FE9A1106298203A900FE48B1 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE9A1105298203A900FE48B1 /* OnboardingView.swift */; };
 		FE9A11082982055400FE48B1 /* SignInWithAppleButtonCustom.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE9A11072982055400FE48B1 /* SignInWithAppleButtonCustom.swift */; };
 		FE9A110A29834FFB00FE48B1 /* OnboardingViewPart2.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE9A110929834FFB00FE48B1 /* OnboardingViewPart2.swift */; };
+		FE9A110C2984935000FE48B1 /* LikeAnimationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE9A110B2984935000FE48B1 /* LikeAnimationView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -71,6 +72,7 @@
 		FE9A1105298203A900FE48B1 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		FE9A11072982055400FE48B1 /* SignInWithAppleButtonCustom.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInWithAppleButtonCustom.swift; sourceTree = "<group>"; };
 		FE9A110929834FFB00FE48B1 /* OnboardingViewPart2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingViewPart2.swift; sourceTree = "<group>"; };
+		FE9A110B2984935000FE48B1 /* LikeAnimationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LikeAnimationView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -142,6 +144,7 @@
 				FE9A10FB2980A11D00FE48B1 /* SettingsLabelView.swift */,
 				FE9A10FD2980C26300FE48B1 /* SettingsRowView.swift */,
 				FE9A11072982055400FE48B1 /* SignInWithAppleButtonCustom.swift */,
+				FE9A110B2984935000FE48B1 /* LikeAnimationView.swift */,
 			);
 			path = Subviews;
 			sourceTree = "<group>";
@@ -270,6 +273,7 @@
 				FE58F5F5297DC204007D53AC /* PostView.swift in Sources */,
 				FE9A10F62980554300FE48B1 /* ProfileView.swift in Sources */,
 				FE58F606297E0960007D53AC /* BrowseView.swift in Sources */,
+				FE9A110C2984935000FE48B1 /* LikeAnimationView.swift in Sources */,
 				FE58F604297DFD9F007D53AC /* CommentModel.swift in Sources */,
 				FE9A11022981C5A600FE48B1 /* SettingsEditImageView.swift in Sources */,
 				FE58F5FC297DE3BD007D53AC /* CommentsView.swift in Sources */,

--- a/DogGram/Views/Screens/ContentView.swift
+++ b/DogGram/Views/Screens/ContentView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct ContentView: View {
     
-    var currentUserID: String? = nil
+    var currentUserID: String? = ""
     
     var body: some View {
         TabView {

--- a/DogGram/Views/Screens/FeedView.swift
+++ b/DogGram/Views/Screens/FeedView.swift
@@ -16,7 +16,7 @@ struct FeedView: View {
         ScrollView(.vertical, showsIndicators: false) {
             LazyVStack {
                 ForEach(posts.dataArray, id: \.self) { post in
-                    PostView(post: post, showHeaderAndFooter: true)
+                    PostView(post: post, addHeartAnimationToView: true, showHeaderAndFooter: true)
                 }
             }
         }

--- a/DogGram/Views/Subviews/ImageGridView.swift
+++ b/DogGram/Views/Subviews/ImageGridView.swift
@@ -23,7 +23,7 @@ struct ImageGridView: View {
             pinnedViews: []) {
                 ForEach(posts.dataArray, id: \.self) { post in
                     NavigationLink(destination: FeedView(posts: PostArrayObject(post: post), title: "Post"), label: {
-                        PostView(post: post, showHeaderAndFooter: false)
+                        PostView(post: post, addHeartAnimationToView: false, showHeaderAndFooter: false)
                     })
                 }
             }

--- a/DogGram/Views/Subviews/LikeAnimationView.swift
+++ b/DogGram/Views/Subviews/LikeAnimationView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct LikeAnimationView: View {
 
-    @State var animate: Bool = true
+    @Binding var animate: Bool
     
     var body: some View {
         
@@ -19,24 +19,30 @@ struct LikeAnimationView: View {
                 .foregroundColor(Color.red.opacity(0.3))
                 .font(.system(size: 200))
                 .opacity(animate ? 1.0 : 0.0)
+                .scaleEffect(animate ? 1.0 : 0.3)
             
             Image(systemName: "heart.fill")
                 .foregroundColor(Color.red.opacity(0.6))
                 .font(.system(size: 150))
                 .opacity(animate ? 1.0 : 0.0)
+                .scaleEffect(animate ? 1.0 : 0.4)
             
             Image(systemName: "heart.fill")
                 .foregroundColor(Color.red.opacity(0.9))
                 .font(.system(size: 100))
                 .opacity(animate ? 1.0 : 0.0)
-            
+                .scaleEffect(animate ? 1.0 : 0.5)
         }
+        .animation(Animation.easeOut(duration: 0.5))
     }
 }
 
 struct LikeAnimationView_Previews: PreviewProvider {
+    
+    @State static var animate: Bool = false
+    
     static var previews: some View {
-        LikeAnimationView()
+        LikeAnimationView(animate: $animate)
             .previewLayout(.sizeThatFits)
     }
 }

--- a/DogGram/Views/Subviews/LikeAnimationView.swift
+++ b/DogGram/Views/Subviews/LikeAnimationView.swift
@@ -1,0 +1,42 @@
+//
+//  LikeAnimationView.swift
+//  DogGram
+//
+//  Created by Matthew Ogtong on 1/27/23.
+//
+
+import SwiftUI
+
+struct LikeAnimationView: View {
+
+    @State var animate: Bool = true
+    
+    var body: some View {
+        
+        ZStack {
+            
+            Image(systemName: "heart.fill")
+                .foregroundColor(Color.red.opacity(0.3))
+                .font(.system(size: 200))
+                .opacity(animate ? 1.0 : 0.0)
+            
+            Image(systemName: "heart.fill")
+                .foregroundColor(Color.red.opacity(0.6))
+                .font(.system(size: 150))
+                .opacity(animate ? 1.0 : 0.0)
+            
+            Image(systemName: "heart.fill")
+                .foregroundColor(Color.red.opacity(0.9))
+                .font(.system(size: 100))
+                .opacity(animate ? 1.0 : 0.0)
+            
+        }
+    }
+}
+
+struct LikeAnimationView_Previews: PreviewProvider {
+    static var previews: some View {
+        LikeAnimationView()
+            .previewLayout(.sizeThatFits)
+    }
+}

--- a/DogGram/Views/Subviews/PostView.swift
+++ b/DogGram/Views/Subviews/PostView.swift
@@ -10,6 +10,9 @@ import SwiftUI
 struct PostView: View {
     
     @State var post: PostModel
+    @State var animateLike: Bool = false
+    @State var addHeartAnimationToView: Bool
+    
     var showHeaderAndFooter: Bool
     
     var body: some View {
@@ -43,16 +46,31 @@ struct PostView: View {
             }
             
             // MARK: IMAGE
-            Image("nimbus2")
-                .resizable()
-                .scaledToFit()
+            ZStack {
+                Image("nimbus2")
+                    .resizable()
+                    .scaledToFit()
+                
+                if addHeartAnimationToView {
+                    LikeAnimationView(animate: $animateLike)
+                }
+            }
             
             // MARK: FOOTER
             if showHeaderAndFooter {
                 HStack(alignment: .center, spacing: 20) {
                     
-                    Image(systemName: "heart")
-                        .font(.title3)
+                    Button {
+                        if post.likedByUser {
+                            unlikePost()
+                        } else {
+                            likePost()
+                        }
+                    } label: {
+                        Image(systemName: post.likedByUser ? "heart.fill" : "heart")
+                            .font(.title3)
+                    }
+                    .foregroundColor(post.likedByUser ? .red : .primary)
                     
                     // MARK: COMMENT ICON
                     NavigationLink {
@@ -81,6 +99,30 @@ struct PostView: View {
             }
         }
     }
+    
+    // MARK: FUNCTIONS
+    
+    func likePost() {
+        
+        // Update the local data
+        let updatedPost = PostModel(postID: post.postID, userID: post.userID, username: post.username, caption: post.caption, dateCreated: post.dateCreated, likeCount: post.likeCount + 1, likedByUser: true)
+        self.post = updatedPost
+        
+        animateLike = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.7) {
+            animateLike = false
+        }
+        
+    }
+    
+    func unlikePost() {
+        
+        // Update the local data
+        let updatedPost = PostModel(postID: post.postID, userID: post.userID, username: post.username, caption: post.caption, dateCreated: post.dateCreated, likeCount: post.likeCount - 1, likedByUser: false)
+        self.post = updatedPost
+        
+    }
+    
 }
 
 struct PostView_Previews: PreviewProvider {
@@ -88,7 +130,7 @@ struct PostView_Previews: PreviewProvider {
     static var post: PostModel = PostModel(postID: "", userID: "", username: "matt", caption: "This is a test caption", dateCreated: Date(), likeCount: 0, likedByUser: false)
     
     static var previews: some View {
-        PostView(post: post, showHeaderAndFooter: true)
+        PostView(post: post, addHeartAnimationToView: true, showHeaderAndFooter: true)
             .previewLayout(.sizeThatFits)
     }
 }


### PR DESCRIPTION
### Description
This pull request adds a new `LikeAnimationView` to the application that displays a heart animation when a post is liked. The animation is implemented using SwiftUI's `ZStack` and `Image` views.

### Changes Made
- Created a new SwiftUI view called `LikeAnimationView` that displays a heart animation when a post is liked.

### How it affects functionality
- When a user likes a post, the `LikeAnimationView` appears and displays a short animation, providing a more engaging and interactive experience for the user.