### PR TITLE
Add post action sheet and dark mode support

### DIFF
--- a/DogGram/Views/Screens/CommentsView.swift
+++ b/DogGram/Views/Screens/CommentsView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 struct CommentsView: View {
     
+    @Environment(\.colorScheme) var colorScheme
+    
     @State var submissionText: String = ""
     @State var commentArray = [CommentModel]()
     
@@ -39,10 +41,11 @@ struct CommentsView: View {
                     Image(systemName: "paperplane.fill")
                         .font(.title2)
                 }
-                .accentColor(Color.MyTheme.purpleColor)
+                .foregroundColor(colorScheme == .light ? Color.MyTheme.purpleColor : Color.MyTheme.yellowColor)
             }
             .padding(.all, 6)
         }
+        .padding(.horizontal)
         .navigationTitle("Comments")
         .navigationBarTitleDisplayMode(.inline)
         .onAppear {

--- a/DogGram/Views/Screens/ContentView.swift
+++ b/DogGram/Views/Screens/ContentView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 struct ContentView: View {
     
+    @Environment(\.colorScheme) var colorScheme
+    
     var currentUserID: String? = ""
     
     var body: some View {
@@ -49,7 +51,7 @@ struct ContentView: View {
                 Text("Profile")
             }
         }
-        .accentColor(Color.MyTheme.purpleColor)
+        .accentColor(colorScheme == .light ? Color.MyTheme.purpleColor : Color.MyTheme.yellowColor)
     }
 }
 

--- a/DogGram/Views/Screens/PostImageView.swift
+++ b/DogGram/Views/Screens/PostImageView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct PostImageView: View {
     
     @Environment(\.presentationMode) var presentationMode
+    @Environment(\.colorScheme) var colorScheme
+    
     @State var captionText: String = ""
     @Binding var imageSelected: UIImage
     
@@ -42,7 +44,7 @@ struct PostImageView: View {
                     .padding()
                     .frame(height: 60)
                     .frame(maxWidth: .infinity)
-                    .background(Color.MyTheme.beigeColor)
+                    .background(colorScheme == .light ? Color.MyTheme.beigeColor : Color.MyTheme.purpleColor)
                     .cornerRadius(12)
                     .font(.headline)
                     .padding(.horizontal)
@@ -57,11 +59,11 @@ struct PostImageView: View {
                         .padding()
                         .frame(height: 60)
                         .frame(maxWidth: .infinity)
-                        .background(Color.MyTheme.purpleColor)
+                        .background(colorScheme == .light ? Color.MyTheme.purpleColor : Color.MyTheme.yellowColor)
                         .cornerRadius(12)
                         .padding(.horizontal)
                 }
-                .accentColor(Color.MyTheme.yellowColor)
+                .accentColor(colorScheme == .light ? Color.MyTheme.yellowColor : Color.MyTheme.purpleColor)
 
             }
             
@@ -81,6 +83,5 @@ struct PostImageView_Previews: PreviewProvider {
     
     static var previews: some View {
         PostImageView(imageSelected: $image)
-            .preferredColorScheme(.light)
     }
 }

--- a/DogGram/Views/Screens/ProfileView.swift
+++ b/DogGram/Views/Screens/ProfileView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 struct ProfileView: View {
     
+    @Environment(\.colorScheme) var colorScheme
+    
     @State var profileDisplayName: String
     @State var showSettings: Bool = false
     
@@ -31,11 +33,12 @@ struct ProfileView: View {
         }, label: {
             Image(systemName: "line.horizontal.3")
         })
-                                    .accentColor(Color.MyTheme.purpleColor)
+                                    .accentColor(colorScheme == .light ? Color.MyTheme.purpleColor : Color.MyTheme.yellowColor)
                                     .opacity(isMyProfile ? 1.0 : 0.0)
         )
         .sheet(isPresented: $showSettings) {
             SettingsView()
+                .preferredColorScheme(colorScheme)
         }
     }
 }

--- a/DogGram/Views/Screens/SettingsEditTextView.swift
+++ b/DogGram/Views/Screens/SettingsEditTextView.swift
@@ -9,6 +9,8 @@ import SwiftUI
 
 struct SettingsEditTextView: View {
     
+    @Environment(\.colorScheme) var colorScheme
+    
     @State var submissionText: String = ""
     @State var title: String
     @State var description: String
@@ -26,7 +28,7 @@ struct SettingsEditTextView: View {
                 .padding()
                 .frame(height: 60)
                 .frame(maxWidth: .infinity)
-                .background(Color.MyTheme.beigeColor)
+                .background(colorScheme == .light ? Color.MyTheme.beigeColor : Color.MyTheme.purpleColor)
                 .cornerRadius(12)
                 .font(.headline)
                 .textInputAutocapitalization(.sentences)
@@ -40,10 +42,10 @@ struct SettingsEditTextView: View {
                     .padding()
                     .frame(height: 60)
                     .frame(maxWidth: .infinity)
-                    .background(Color.MyTheme.purpleColor)
+                    .background(colorScheme == .light ? Color.MyTheme.purpleColor : Color.MyTheme.yellowColor)
                     .cornerRadius(12)
             }
-            .foregroundColor(Color.MyTheme.yellowColor)
+            .foregroundColor(colorScheme == .light ? Color.MyTheme.yellowColor : Color.MyTheme.purpleColor)
 
             Spacer()
             

--- a/DogGram/Views/Screens/SettingsView.swift
+++ b/DogGram/Views/Screens/SettingsView.swift
@@ -10,6 +10,7 @@ import SwiftUI
 struct SettingsView: View {
     
     @Environment(\.presentationMode) var presentationMode
+    @Environment(\.colorScheme) var colorScheme
     
     var body: some View {
         NavigationView {
@@ -109,6 +110,7 @@ struct SettingsView: View {
                                         .accentColor(.primary)
             )
         }
+        .foregroundColor(colorScheme == .light ? Color.MyTheme.purpleColor : Color.MyTheme.yellowColor)
     }
     
     // MARK: FUNCTIONS

--- a/DogGram/Views/Screens/SignUpView.swift
+++ b/DogGram/Views/Screens/SignUpView.swift
@@ -32,6 +32,7 @@ struct SignUpView: View {
                 .font(.headline)
                 .fontWeight(.medium)
                 .multilineTextAlignment(.center)
+                .foregroundColor(Color.MyTheme.purpleColor)
             
             Button {
                 showOnboarding.toggle()

--- a/DogGram/Views/Screens/UploadView.swift
+++ b/DogGram/Views/Screens/UploadView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 
 struct UploadView: View {
     
+    @Environment(\.colorScheme) var colorScheme
+    
     @State var showImagePicker: Bool = false
     @State var imageSelected: UIImage = UIImage(named: "logo")!
     @State var sourceType: UIImagePickerController.SourceType = .camera
@@ -45,6 +47,8 @@ struct UploadView: View {
             }
             .sheet(isPresented: $showImagePicker, onDismiss: segueToPostImageView) {
                 ImagePicker(imageSelected: $imageSelected, sourceType: $sourceType)
+                    .preferredColorScheme(colorScheme)
+                    .foregroundColor(colorScheme == .light ? Color.MyTheme.purpleColor : Color.MyTheme.yellowColor)
             }
             
             Image("logo.transparent")
@@ -54,6 +58,7 @@ struct UploadView: View {
                 .shadow(radius: 12)
                 .fullScreenCover(isPresented: $showPostImageView) {
                     PostImageView(imageSelected: $imageSelected)
+                        .preferredColorScheme(colorScheme)
                 }
         }
         .edgesIgnoringSafeArea(.top)

--- a/DogGram/Views/Subviews/PostView.swift
+++ b/DogGram/Views/Subviews/PostView.swift
@@ -9,9 +9,17 @@ import SwiftUI
 
 struct PostView: View {
     
+    enum PostActionSheetOption {
+        case general
+        case reporting
+    }
+    
     @State var post: PostModel
+    @State var postImage: UIImage = UIImage(named: "nimbus2")!
     @State var animateLike: Bool = false
     @State var addHeartAnimationToView: Bool
+    @State var showActionSheet: Bool = false
+    @State var actionSheetType: PostActionSheetOption = .general
     
     var showHeaderAndFooter: Bool
     
@@ -39,15 +47,24 @@ struct PostView: View {
                     
                     Spacer()
                     
-                    Image(systemName: "ellipsis")
-                        .font(.headline)
+                    Button {
+                        showActionSheet.toggle()
+                    } label: {
+                        Image(systemName: "ellipsis")
+                            .font(.headline)
+                    }
+                    .foregroundColor(.primary)
+                    .actionSheet(isPresented: $showActionSheet) {
+                        getActionSheet()
+                    }
+                    
                 }
                 .padding(.all, 6)
             }
             
             // MARK: IMAGE
             ZStack {
-                Image("nimbus2")
+                Image(uiImage: postImage)
                     .resizable()
                     .scaledToFit()
                 
@@ -81,8 +98,13 @@ struct PostView: View {
                             .foregroundColor(.primary)
                     }
                     
-                    Image(systemName: "paperplane")
-                        .font(.title3)
+                    Button {
+                        sharePost()
+                    } label: {
+                        Image(systemName: "paperplane")
+                            .font(.title3)
+                    }
+                    .foregroundColor(.primary)
                     
                     Spacer()
                 }
@@ -121,6 +143,68 @@ struct PostView: View {
         let updatedPost = PostModel(postID: post.postID, userID: post.userID, username: post.username, caption: post.caption, dateCreated: post.dateCreated, likeCount: post.likeCount - 1, likedByUser: false)
         self.post = updatedPost
         
+    }
+    
+    func getActionSheet() -> ActionSheet {
+        
+        switch self.actionSheetType {
+        case .general:
+            return ActionSheet(title: Text("Where would you like to go?"), message: nil, buttons: [
+                .destructive(Text("Report"), action: {
+                    self.actionSheetType = .reporting
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                        self.showActionSheet.toggle()
+                    }
+                }),
+                .default(Text("Learn more..."), action: {
+                    print("LEARN MORE PRESSED")
+                }),
+                .cancel()
+            ])
+        case .reporting:
+            return ActionSheet(title: Text("Why are you reporting this post?"), message: nil, buttons: [
+                
+                .destructive(Text("This is inappropriate"), action: {
+                    reportPost(reason: "This is inappropriate")
+                }),
+                .destructive(Text("This is spam"), action: {
+                    reportPost(reason: "This is spam")
+                }),
+                .destructive(Text("It made me uncomfortable"), action: {
+                    reportPost(reason: "It made me uncomfortable")
+                }),
+                .cancel({
+                    self.actionSheetType = .general
+                })
+                
+            ])
+        }
+        
+    }
+    
+    func reportPost(reason: String) {
+        print("REPORT POST NOW")
+    }
+    
+    func sharePost() {
+        
+        let message = "Check out this post on DogGram!"
+        let image = postImage
+        let link = URL(string: "https://www.google.com")!
+        
+        let activityViewController = UIActivityViewController(activityItems: [message, image, link], applicationActivities: nil)
+        
+        guard let firstScene = UIApplication.shared.connectedScenes.first as? UIWindowScene else {
+            return
+        }
+        
+        guard let firstWindow = firstScene.windows.first else {
+            return
+        }
+        
+        let viewController = firstWindow.rootViewController
+        
+        viewController?.present(activityViewController, animated: true, completion: nil)
     }
     
 }


### PR DESCRIPTION
### Changes
- Implemented post action sheet with reporting and sharing options in the `PostView` screen
- Added support for dark mode throughout the project
### Details
- The post action sheet is triggered by clicking the ellipsis button and provides options to report or share the post
- The report feature allows the user to specify why they are reporting the post
- The share feature uses the `UIActivityViewController` to share the post along with a message and a link
- The project now supports dark mode, providing a consistent and accessible experience for users